### PR TITLE
feat: add remove commands and forward-looking calendar

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trakt",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Track movies and TV shows using trakt.tv CLI",
   "author": { "name": "Omar Shahine" },
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
    ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝        ╚═════╝╚══════╝╚═╝
 ```
 
-A CLI and AI agent plugin for [Trakt.tv](https://trakt.tv) using the [Trakt API](https://trakt.docs.apiary.io/). Search movies and shows, view watch history, manage your watchlist (add + view), track show progress, and mark items as watched.
+A CLI and AI agent plugin for [Trakt.tv](https://trakt.tv) using the [Trakt API](https://trakt.docs.apiary.io/). Search movies and shows, view and manage your watchlist (add/remove), view and edit watch history (add/remove), track show progress, check the upcoming-episodes calendar, and mark items as watched.
 
 Ships as both a standalone Go CLI and as plugins for [OpenClaw](https://docs.openclaw.ai/) and [Claude Code](https://claude.ai/claude-code).
 
@@ -102,6 +102,19 @@ trakt-cli history add --watched-at 2025-06-15 "Dark" --json
 | `--type` | `show` or `movie` | `show` |
 | `--watched-at` | YYYY-MM-DD or RFC3339 | now |
 
+### history remove
+
+Undo a mark-as-watched. Removing a show wipes ALL its episode plays; removing a movie wipes all its watches. There is no per-watch granular removal — Trakt's API removes by trakt id, not by timestamp.
+
+```bash
+trakt-cli history remove "Severance" --json
+trakt-cli history remove --type movie "The Godfather" --json
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--type` | `show` or `movie` | `show` |
+
 ### watchlist
 
 View your watchlist.
@@ -132,6 +145,36 @@ trakt-cli watchlist add --type movie "Oppenheimer" --json
 |------|-------------|---------|
 | `--type` | `show` or `movie` | `show` |
 
+### watchlist remove
+
+Remove movies or shows from your watchlist. Searches by title. Items that were not on the list are silent no-ops (`deleted_*=0`, not an error).
+
+```bash
+trakt-cli watchlist remove "Severance" --json
+trakt-cli watchlist remove --type movie "Oppenheimer" --json
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--type` | `show` or `movie` | `show` |
+
+### calendar
+
+Show upcoming episodes of shows you watch. This is the only read command that returns **forward-looking** data — ideal for proactive "what airs next?" workflows.
+
+```bash
+trakt-cli calendar --json
+trakt-cli calendar --days 14 --json
+trakt-cli calendar --start 2026-04-10 --days 7 --json
+trakt-cli calendar --new --days 30 --json  # series premieres only
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--days` | Number of days to look ahead | 7 |
+| `--start` | Start date (YYYY-MM-DD) | today |
+| `--new` | Only series premieres (S01E01 airings) | off |
+
 ### progress
 
 Show watch progress for watchlist TV shows.
@@ -149,7 +192,7 @@ trakt-cli progress --all --json
 
 ### OpenClaw
 
-The `openclaw/` directory contains a native OpenClaw plugin that registers typed tools: `trakt_search`, `trakt_history`, `trakt_history_add`, `trakt_watchlist`, `trakt_watchlist_add`, `trakt_progress`, and `trakt_auth`.
+The `openclaw/` directory contains a native OpenClaw plugin that registers typed tools: `trakt_search`, `trakt_history`, `trakt_history_add`, `trakt_history_remove`, `trakt_watchlist`, `trakt_watchlist_add`, `trakt_watchlist_remove`, `trakt_calendar`, `trakt_progress`, and `trakt_auth`.
 
 Install from ClawHub:
 ```bash

--- a/api/api.go
+++ b/api/api.go
@@ -843,8 +843,14 @@ func (c *APIClient) GetMyShowsCalendar(start string, days int, onlyNew bool) ([]
 	// Trakt's URL shape is /calendars/my/shows[/new]/{start_date}/{days}.
 	// Both path segments are optional but must be supplied together — you
 	// can't specify days without start_date.
+	//
+	// Use LOCAL time (not UTC) for the default start date: a user in
+	// UTC+12 at 1 AM local is still on yesterday's UTC date, but from
+	// their perspective "today's calendar" means their local today, not
+	// UTC's today. Trakt treats the date string as a calendar date, so
+	// feeding it the user's local date is the right behavior.
 	if start == "" {
-		start = time.Now().UTC().Format("2006-01-02")
+		start = time.Now().Format("2006-01-02")
 	}
 	if days <= 0 {
 		days = 7

--- a/api/api.go
+++ b/api/api.go
@@ -709,6 +709,171 @@ func (c *APIClient) AddWatchlist(req *SyncWatchlistReq) (*SyncWatchlistResp, err
 	return &resp, nil
 }
 
+// RemoveWatchlistResp mirrors POST /sync/watchlist/remove. Same shape as the
+// add response except `deleted` replaces `added`, and there's no `existing`
+// bucket (items not on the list are silently no-ops, counted as 0 deleted).
+type RemoveWatchlistResp struct {
+	Deleted struct {
+		Movies int `json:"movies"`
+		Shows  int `json:"shows"`
+	} `json:"deleted"`
+	NotFound struct {
+		Movies []interface{} `json:"movies"`
+		Shows  []interface{} `json:"shows"`
+	} `json:"not_found"`
+}
+
+// RemoveWatchlist POSTs items to /sync/watchlist/remove. Request body is
+// the same shape as SyncWatchlistReq — we reuse it rather than defining a
+// near-identical type.
+func (c *APIClient) RemoveWatchlist(req *SyncWatchlistReq) (*RemoveWatchlistResp, error) {
+	httpResp, err := c.doRequest(requestParams{
+		method: http.MethodPost,
+		path:   "/sync/watchlist/remove",
+		body:   req,
+		auth:   true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != 200 {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("remove watchlist failed (%s): %s", httpResp.Status, string(body))
+	}
+
+	var resp RemoveWatchlistResp
+	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// RemoveHistoryResp mirrors POST /sync/history/remove. Trakt returns the
+// deleted counts under `deleted.{movies,episodes}` (not "shows" — removing
+// a show from history removes all its episodes, which get counted at the
+// episode grain).
+type RemoveHistoryResp struct {
+	Deleted struct {
+		Movies   int `json:"movies"`
+		Episodes int `json:"episodes"`
+	} `json:"deleted"`
+	NotFound struct {
+		Movies   []interface{} `json:"movies"`
+		Shows    []interface{} `json:"shows"`
+		Seasons  []interface{} `json:"seasons"`
+		Episodes []interface{} `json:"episodes"`
+		Ids      []interface{} `json:"ids"`
+	} `json:"not_found"`
+}
+
+// RemoveHistory POSTs items to /sync/history/remove. Request body is the
+// same shape as SyncHistoryReq (reused), but WatchedAt is ignored by the
+// server on the remove path — removing by trakt id removes ALL plays of
+// that item from history, not just the one at a given timestamp.
+func (c *APIClient) RemoveHistory(req *SyncHistoryReq) (*RemoveHistoryResp, error) {
+	httpResp, err := c.doRequest(requestParams{
+		method: http.MethodPost,
+		path:   "/sync/history/remove",
+		body:   req,
+		auth:   true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != 200 {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("remove history failed (%s): %s", httpResp.Status, string(body))
+	}
+
+	var resp RemoveHistoryResp
+	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// CalendarEpisode is one entry from /calendars/my/shows. Each row is a
+// single episode airing on a specific date — a show with 3 new episodes
+// in the window produces 3 rows.
+type CalendarEpisode struct {
+	FirstAired time.Time `json:"first_aired"`
+	Episode    struct {
+		Season int    `json:"season"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Ids    struct {
+			Trakt int    `json:"trakt"`
+			Tvdb  int    `json:"tvdb"`
+			Imdb  string `json:"imdb"`
+			Tmdb  int    `json:"tmdb"`
+		} `json:"ids"`
+	} `json:"episode"`
+	Show struct {
+		Title string `json:"title"`
+		Year  int    `json:"year"`
+		Ids   struct {
+			Trakt int    `json:"trakt"`
+			Slug  string `json:"slug"`
+			Tvdb  int    `json:"tvdb"`
+			Imdb  string `json:"imdb"`
+			Tmdb  int    `json:"tmdb"`
+		} `json:"ids"`
+	} `json:"show"`
+}
+
+// GetMyShowsCalendar returns upcoming episodes of shows the user watches,
+// over a window starting at `start` (YYYY-MM-DD) for `days` days. Pass an
+// empty start to default to today per Trakt's server-side default. When
+// `onlyNew` is true, hits /calendars/my/shows/new instead (series premieres
+// only — S01E01 airings).
+func (c *APIClient) GetMyShowsCalendar(start string, days int, onlyNew bool) ([]CalendarEpisode, error) {
+	base := "/calendars/my/shows"
+	if onlyNew {
+		base = "/calendars/my/shows/new"
+	}
+	path := base
+	// Trakt's URL shape is /calendars/my/shows[/new]/{start_date}/{days}.
+	// Both path segments are optional but must be supplied together — you
+	// can't specify days without start_date.
+	if start == "" {
+		start = time.Now().UTC().Format("2006-01-02")
+	}
+	if days <= 0 {
+		days = 7
+	}
+	path = fmt.Sprintf("%s/%s/%d", path, start, days)
+
+	httpResp, err := c.doRequest(requestParams{
+		method: http.MethodGet,
+		path:   path,
+		auth:   true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to get calendar: %s", httpResp.Status)
+	}
+
+	var resp []CalendarEpisode
+	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 func (c *APIClient) Search(query string, searchType string) ([]SearchResult, error) {
 	httpResp, err := c.doRequest(requestParams{
 		method: http.MethodGet,

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/mergestat/timediff"
+	"github.com/muesli/termenv"
+	"github.com/omarshahine/trakt-plugin/api"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// calendarCmd shows upcoming episodes for shows the user tracks on Trakt.
+// Unlike every other read command in this CLI, calendar data is
+// FORWARD-looking — it enables proactive agent workflows (e.g., "new
+// episode of X drops on Friday") that the rest of the tools can't support
+// since they only describe current/past state.
+var calendarCmd = &cobra.Command{
+	Use:   "calendar",
+	Short: "Show upcoming episodes of shows you watch",
+	Long:  `Show upcoming episodes of shows on your watchlist/history, in a date window. Defaults to the next 7 days starting today.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewAPIClient()
+
+		start, _ := cmd.Flags().GetString("start")
+		days, _ := cmd.Flags().GetInt("days")
+		onlyNew, _ := cmd.Flags().GetBool("new")
+
+		// Validate start if provided — reject a malformed date up front so
+		// the user sees a clear error instead of a 404 from Trakt.
+		if start != "" {
+			if _, err := time.Parse("2006-01-02", start); err != nil {
+				logrus.Fatalf("Invalid --start format. Use YYYY-MM-DD (e.g. 2026-04-10)")
+			}
+		}
+
+		s := spinner.New(spinner.CharSets[2], 100*time.Millisecond)
+		if !jsonOutput {
+			s.Prefix = "Loading calendar... "
+			s.Start()
+		}
+
+		episodes, err := client.GetMyShowsCalendar(start, days, onlyNew)
+		s.Stop()
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to load calendar")
+		}
+
+		if jsonOutput {
+			type jsonItem struct {
+				FirstAired  string `json:"first_aired"`
+				ShowTitle   string `json:"show_title"`
+				ShowYear    int    `json:"show_year"`
+				ShowTraktID int    `json:"show_trakt_id"`
+				Season      int    `json:"season"`
+				Episode     int    `json:"episode"`
+				Title       string `json:"title"`
+			}
+			items := make([]jsonItem, 0, len(episodes))
+			for _, e := range episodes {
+				items = append(items, jsonItem{
+					FirstAired:  e.FirstAired.Format(time.RFC3339),
+					ShowTitle:   e.Show.Title,
+					ShowYear:    e.Show.Year,
+					ShowTraktID: e.Show.Ids.Trakt,
+					Season:      e.Episode.Season,
+					Episode:     e.Episode.Number,
+					Title:       e.Episode.Title,
+				})
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(map[string]interface{}{
+				"items": items,
+				"count": len(items),
+			})
+			return
+		}
+
+		if len(episodes) == 0 {
+			fmt.Println("No upcoming episodes in the window.")
+			return
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{
+			termenv.String("Airs").Bold(),
+			termenv.String("Show").Bold(),
+			termenv.String("Episode").Bold(),
+			termenv.String("Title").Bold(),
+		})
+		for _, e := range episodes {
+			p := termenv.ColorProfile()
+			year := termenv.String(fmt.Sprintf("(%d)", e.Show.Year)).Foreground(p.Color("#B9BFCA"))
+			t.AppendRow([]interface{}{
+				timediff.TimeDiff(e.FirstAired),
+				fmt.Sprintf("%s %s", e.Show.Title, year),
+				fmt.Sprintf("S%02dE%02d", e.Episode.Season, e.Episode.Number),
+				e.Episode.Title,
+			})
+		}
+		t.SetStyle(table.StyleRounded)
+		t.Render()
+
+		fmt.Printf("%d upcoming episodes\n", len(episodes))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(calendarCmd)
+	calendarCmd.Flags().String("start", "", "Start date (YYYY-MM-DD, defaults to today)")
+	calendarCmd.Flags().Int("days", 7, "Number of days to look ahead")
+	calendarCmd.Flags().Bool("new", false, "Only show series premieres (S01E01 airings)")
+}

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -39,6 +39,13 @@ var calendarCmd = &cobra.Command{
 			}
 		}
 
+		// Fail fast on nonsensical windows. The API layer has a safety net
+		// that resets <=0 to 7, but that silently rewrites user input —
+		// better to reject it here so the mistake is visible.
+		if days <= 0 {
+			logrus.Fatalf("--days must be a positive integer (got %d)", days)
+		}
+
 		s := spinner.New(spinner.CharSets[2], 100*time.Millisecond)
 		if !jsonOutput {
 			s.Prefix = "Loading calendar... "
@@ -95,8 +102,10 @@ var calendarCmd = &cobra.Command{
 			termenv.String("Episode").Bold(),
 			termenv.String("Title").Bold(),
 		})
+		// Hoist terminal-capability detection out of the loop — it's
+		// invariant across iterations.
+		p := termenv.ColorProfile()
 		for _, e := range episodes {
-			p := termenv.ColorProfile()
 			year := termenv.String(fmt.Sprintf("(%d)", e.Show.Year)).Foreground(p.Color("#B9BFCA"))
 			t.AppendRow([]interface{}{
 				timediff.TimeDiff(e.FirstAired),

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -63,7 +63,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "trakt-cli") {
 		t.Error("--help should mention trakt-cli")
 	}
-	for _, cmd := range []string{"auth", "search", "history", "watchlist", "progress"} {
+	for _, cmd := range []string{"auth", "search", "history", "watchlist", "progress", "calendar"} {
 		if !strings.Contains(out, cmd) {
 			t.Errorf("--help should list %q command", cmd)
 		}
@@ -97,7 +97,10 @@ func TestSubcommandHelp(t *testing.T) {
 		{[]string{"watchlist", "--help"}, "watchlist"},
 		{[]string{"progress", "--help"}, "in progress"},
 		{[]string{"history", "add", "--help"}, "watch history"},
+		{[]string{"history", "remove", "--help"}, "watch history"},
 		{[]string{"watchlist", "add", "--help"}, "watchlist"},
+		{[]string{"watchlist", "remove", "--help"}, "watchlist"},
+		{[]string{"calendar", "--help"}, "upcoming episodes"},
 	}
 	for _, tc := range cmds {
 		t.Run(strings.Join(tc.args, "_"), func(t *testing.T) {

--- a/cmd/history_remove.go
+++ b/cmd/history_remove.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/muesli/termenv"
+	"github.com/omarshahine/trakt-plugin/api"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// historyRemoveCmd is the symmetric inverse of history_add. Removing by
+// trakt id wipes ALL plays of that item from history — there's no partial
+// "remove one watch on this date" semantics, which is why there's no
+// --watched-at flag on this command.
+var historyRemoveCmd = &cobra.Command{
+	Use:   "remove [show or movie names...]",
+	Short: "Remove items from your watch history",
+	Long:  `Search for shows or movies by name and remove them from your Trakt watch history. Removing a show deletes all episode plays; removing a movie deletes all watches.`,
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewAPIClient()
+		itemType, _ := cmd.Flags().GetString("type")
+		searchType := itemType
+		if searchType != "movie" {
+			searchType = "show"
+		}
+
+		s := spinner.New(spinner.CharSets[2], 100*time.Millisecond)
+		syncReq := &api.SyncHistoryReq{}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{
+			termenv.String("Query").Bold(),
+			termenv.String("Matched").Bold(),
+			termenv.String("Year").Bold(),
+			termenv.String("Trakt ID").Bold(),
+		})
+
+		for _, query := range args {
+			if !jsonOutput {
+				s.Prefix = fmt.Sprintf("Searching for \"%s\"... ", query)
+				s.Start()
+			}
+
+			results, err := client.Search(query, searchType)
+			s.Stop()
+			if err != nil {
+				logrus.WithError(err).Errorf("Failed to search for %s", query)
+				continue
+			}
+
+			if len(results) == 0 {
+				p := termenv.ColorProfile()
+				t.AppendRow([]interface{}{
+					query,
+					termenv.String("NOT FOUND").Foreground(p.Color("#FF6B6B")),
+					"",
+					"",
+				})
+				continue
+			}
+
+			result := results[0]
+			queryLower := strings.ToLower(strings.TrimSpace(query))
+			for _, r := range results {
+				var title string
+				if searchType == "movie" && r.Movie != nil {
+					title = r.Movie.Title
+				} else if r.Show != nil {
+					title = r.Show.Title
+				}
+				if strings.ToLower(title) == queryLower {
+					result = r
+					break
+				}
+			}
+			item := api.SyncItem{}
+
+			if searchType == "movie" && result.Movie != nil {
+				item.Ids.Trakt = result.Movie.Ids.Trakt
+				syncReq.Movies = append(syncReq.Movies, item)
+				t.AppendRow([]interface{}{
+					query,
+					result.Movie.Title,
+					result.Movie.Year,
+					result.Movie.Ids.Trakt,
+				})
+			} else if result.Show != nil {
+				item.Ids.Trakt = result.Show.Ids.Trakt
+				syncReq.Shows = append(syncReq.Shows, item)
+				t.AppendRow([]interface{}{
+					query,
+					result.Show.Title,
+					result.Show.Year,
+					result.Show.Ids.Trakt,
+				})
+			}
+		}
+
+		if !jsonOutput {
+			t.SetStyle(table.StyleRounded)
+			t.Render()
+		}
+
+		if len(syncReq.Shows) == 0 && len(syncReq.Movies) == 0 {
+			if jsonOutput {
+				fmt.Println("{\"error\": \"no items matched\"}")
+			} else {
+				fmt.Println("\nNo items to remove.")
+			}
+			return
+		}
+
+		if !jsonOutput {
+			fmt.Printf("\nRemoving %d shows and %d movies from history...\n", len(syncReq.Shows), len(syncReq.Movies))
+			s.Prefix = "Syncing... "
+			s.Start()
+		}
+		resp, err := client.RemoveHistory(syncReq)
+		s.Stop()
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to remove from history")
+		}
+
+		if jsonOutput {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(map[string]interface{}{
+				"deleted_movies":   resp.Deleted.Movies,
+				"deleted_episodes": resp.Deleted.Episodes,
+				"not_found_movies": len(resp.NotFound.Movies),
+				"not_found_shows":  len(resp.NotFound.Shows),
+			})
+			return
+		}
+
+		fmt.Printf("Deleted: %d movies, %d episodes\n", resp.Deleted.Movies, resp.Deleted.Episodes)
+		if len(resp.NotFound.Movies) > 0 || len(resp.NotFound.Shows) > 0 {
+			fmt.Printf("Not found: %d movies, %d shows\n", len(resp.NotFound.Movies), len(resp.NotFound.Shows))
+		}
+	},
+}
+
+func init() {
+	historyCmd.AddCommand(historyRemoveCmd)
+	historyRemoveCmd.Flags().String("type", "show", "Type of item (show, movie)")
+}

--- a/cmd/watchlist_remove.go
+++ b/cmd/watchlist_remove.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/muesli/termenv"
+	"github.com/omarshahine/trakt-plugin/api"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// watchlistRemoveCmd is the symmetric inverse of watchlist_add: search by
+// title, pick the best match, and POST all matches to /sync/watchlist/remove
+// in one sync call. Items that weren't on the watchlist are silently no-ops
+// (Trakt returns deleted=0 for them, not an error).
+var watchlistRemoveCmd = &cobra.Command{
+	Use:   "remove [show or movie names...]",
+	Short: "Remove items from your watchlist",
+	Long:  `Search for shows or movies by name and remove them from your Trakt watchlist.`,
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewAPIClient()
+		itemType, _ := cmd.Flags().GetString("type")
+		searchType := itemType
+		if searchType != "movie" {
+			searchType = "show"
+		}
+
+		s := spinner.New(spinner.CharSets[2], 100*time.Millisecond)
+		syncReq := &api.SyncWatchlistReq{}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{
+			termenv.String("Query").Bold(),
+			termenv.String("Matched").Bold(),
+			termenv.String("Year").Bold(),
+			termenv.String("Trakt ID").Bold(),
+		})
+
+		for _, query := range args {
+			if !jsonOutput {
+				s.Prefix = fmt.Sprintf("Searching for \"%s\"... ", query)
+				s.Start()
+			}
+
+			results, err := client.Search(query, searchType)
+			s.Stop()
+			if err != nil {
+				logrus.WithError(err).Errorf("Failed to search for %s", query)
+				continue
+			}
+
+			if len(results) == 0 {
+				p := termenv.ColorProfile()
+				t.AppendRow([]interface{}{
+					query,
+					termenv.String("NOT FOUND").Foreground(p.Color("#FF6B6B")),
+					"",
+					"",
+				})
+				continue
+			}
+
+			result := results[0]
+			queryLower := strings.ToLower(strings.TrimSpace(query))
+			for _, r := range results {
+				var title string
+				if searchType == "movie" && r.Movie != nil {
+					title = r.Movie.Title
+				} else if r.Show != nil {
+					title = r.Show.Title
+				}
+				if strings.ToLower(title) == queryLower {
+					result = r
+					break
+				}
+			}
+			item := api.SyncItem{}
+
+			if searchType == "movie" && result.Movie != nil {
+				item.Ids.Trakt = result.Movie.Ids.Trakt
+				syncReq.Movies = append(syncReq.Movies, item)
+				t.AppendRow([]interface{}{
+					query,
+					result.Movie.Title,
+					result.Movie.Year,
+					result.Movie.Ids.Trakt,
+				})
+			} else if result.Show != nil {
+				item.Ids.Trakt = result.Show.Ids.Trakt
+				syncReq.Shows = append(syncReq.Shows, item)
+				t.AppendRow([]interface{}{
+					query,
+					result.Show.Title,
+					result.Show.Year,
+					result.Show.Ids.Trakt,
+				})
+			}
+		}
+
+		if !jsonOutput {
+			t.SetStyle(table.StyleRounded)
+			t.Render()
+		}
+
+		if len(syncReq.Shows) == 0 && len(syncReq.Movies) == 0 {
+			if jsonOutput {
+				fmt.Println("{\"error\": \"no items matched\"}")
+			} else {
+				fmt.Println("\nNo items to remove.")
+			}
+			return
+		}
+
+		if !jsonOutput {
+			fmt.Printf("\nRemoving %d shows and %d movies from watchlist...\n", len(syncReq.Shows), len(syncReq.Movies))
+			s.Prefix = "Syncing... "
+			s.Start()
+		}
+		resp, err := client.RemoveWatchlist(syncReq)
+		s.Stop()
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to remove from watchlist")
+		}
+
+		if jsonOutput {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(map[string]interface{}{
+				"deleted_movies":   resp.Deleted.Movies,
+				"deleted_shows":    resp.Deleted.Shows,
+				"not_found_movies": len(resp.NotFound.Movies),
+				"not_found_shows":  len(resp.NotFound.Shows),
+			})
+			return
+		}
+
+		fmt.Printf("Deleted: %d movies, %d shows\n", resp.Deleted.Movies, resp.Deleted.Shows)
+		if len(resp.NotFound.Movies) > 0 || len(resp.NotFound.Shows) > 0 {
+			fmt.Printf("Not found: %d movies, %d shows\n", len(resp.NotFound.Movies), len(resp.NotFound.Shows))
+		}
+	},
+}
+
+func init() {
+	watchlistCmd.AddCommand(watchlistRemoveCmd)
+	watchlistRemoveCmd.Flags().String("type", "show", "Type of item (show, movie)")
+}

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
       "name": "trakt",
       "source": "./openclaw",
       "description": "Track movies and TV shows via trakt.tv",
-      "version": "1.7.0"
+      "version": "1.8.0"
     }
   ]
 }

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "trakt-tools",
   "name": "Trakt",
   "description": "Track movies and TV shows using trakt.tv",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trakt-tools",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenClaw plugin for Trakt.tv - track movies and TV shows",
   "type": "module",
   "openclaw": {

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -82,6 +82,24 @@ const TOOLS: ToolDef[] = [
 		}),
 	},
 	{
+		name: 'trakt_history_remove',
+		command: 'history',
+		subcommand: 'remove',
+		description:
+			'Remove movies or shows from Trakt.tv watch history (undo a mark-as-watched). Searches by title; removing a show wipes ALL its episode plays, removing a movie wipes all its watches. There is no per-watch granular removal.',
+		parameters: Type.Object({
+			titles: Type.Array(Type.String(), {
+				description: 'Title(s) to remove from history',
+				minItems: 1,
+			}),
+			type: Type.Optional(
+				Type.Union([Type.Literal('movie'), Type.Literal('show')], {
+					description: 'Content type (default: show)',
+				})
+			),
+		}),
+	},
+	{
 		name: 'trakt_watchlist',
 		command: 'watchlist',
 		description:
@@ -110,6 +128,43 @@ const TOOLS: ToolDef[] = [
 			type: Type.Optional(
 				Type.Union([Type.Literal('movie'), Type.Literal('show')], {
 					description: 'Content type (default: show)',
+				})
+			),
+		}),
+	},
+	{
+		name: 'trakt_watchlist_remove',
+		command: 'watchlist',
+		subcommand: 'remove',
+		description:
+			'Remove movies or shows from the Trakt.tv watchlist. Searches by title and removes matches in one sync call. Accepts multiple titles. Items that were not on the list are silent no-ops (deleted_*=0).',
+		parameters: Type.Object({
+			titles: Type.Array(Type.String(), {
+				description: 'Title(s) to remove from the watchlist',
+				minItems: 1,
+			}),
+			type: Type.Optional(
+				Type.Union([Type.Literal('movie'), Type.Literal('show')], {
+					description: 'Content type (default: show)',
+				})
+			),
+		}),
+	},
+	{
+		name: 'trakt_calendar',
+		command: 'calendar',
+		description:
+			'Show upcoming episodes of shows you watch. Returns forward-looking airings within a date window. Use for proactive "what airs next?" workflows — this is the only trakt tool that returns future data.',
+		parameters: Type.Object({
+			days: Type.Optional(
+				Type.Number({ description: 'Number of days to look ahead (default 7)' })
+			),
+			start: Type.Optional(
+				Type.String({ description: 'Start date YYYY-MM-DD (defaults to today)' })
+			),
+			new: Type.Optional(
+				Type.Boolean({
+					description: 'Only return series premieres (S01E01 airings)',
 				})
 			),
 		}),
@@ -226,10 +281,15 @@ function buildCliArgs(
 		}
 	}
 
-	// watchlist add: same title-array shape as history add, minus watched_at
-	// (the watchlist API has no "added at" field — Trakt assigns listed_at
-	// server-side at sync time).
-	if (command === 'watchlist' && subcommand === 'add') {
+	// Title-array commands (watchlist add/remove, history remove) all share
+	// the same shape: search by title, POST the matches. Only `history add`
+	// needs special handling for --watched-at.
+	const titleArrayCommands: Array<[string, string]> = [
+		['watchlist', 'add'],
+		['watchlist', 'remove'],
+		['history', 'remove'],
+	];
+	if (titleArrayCommands.some(([c, s]) => c === command && s === subcommand)) {
 		const titles = params.titles as string[] | undefined;
 		if (titles) {
 			if (params.type) args.push('--type', String(params.type));

--- a/skills/trakt/SKILL.md
+++ b/skills/trakt/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: trakt
 description: |
-  Search movies/shows, view watch history, check and update the watchlist, track progress, and mark items as watched on Trakt.tv.
-  Use when the user asks what they've been watching, what's on their watchlist, what's in progress,
-  wants to add or find a movie or show, mark something as watched, or asks about their Trakt activity.
+  Search movies/shows, view watch history, check and update the watchlist, track progress, view the upcoming-episodes calendar, and mark items as watched (or undo) on Trakt.tv.
+  Use when the user asks what they've been watching, what's on their watchlist, what's in progress, what airs next,
+  wants to add/remove a movie or show, mark something as watched, undo a watch, or asks about their Trakt activity.
 ---
 
 # Trakt Skill
@@ -55,6 +55,32 @@ trakt-cli watchlist add --type movie "Oppenheimer" --json
 - Duplicates are NOT an error — items already on the list come back under `existing_*` counts
 - JSON output: `{ "added_movies", "added_shows", "existing_movies", "existing_shows", "not_found_movies", "not_found_shows" }`
 
+### Remove from Watchlist
+
+```bash
+trakt-cli watchlist remove "Severance" --json
+trakt-cli watchlist remove --type movie "Oppenheimer" --json
+```
+
+- Symmetric inverse of `watchlist add`
+- Items not on the list are silent no-ops (`deleted_*=0`, not an error)
+- JSON output: `{ "deleted_movies", "deleted_shows", "not_found_movies", "not_found_shows" }`
+
+### Calendar (Upcoming Episodes)
+
+```bash
+trakt-cli calendar --json                    # next 7 days starting today
+trakt-cli calendar --days 14 --json          # next 14 days
+trakt-cli calendar --start 2026-04-10 --days 7 --json
+trakt-cli calendar --new --days 30 --json    # series premieres only
+```
+
+- **Only forward-looking trakt command** — use it whenever the user asks "when does X come back?" or "what's new this week?"
+- Covers shows already in the user's watchlist/history (Trakt derives "my shows" from these)
+- JSON output: `{ "items": [{ "first_aired", "show_title", "show_year", "show_trakt_id", "season", "episode", "title" }], "count" }`
+- One row per episode airing — a show with 3 new episodes in the window produces 3 rows
+- `--new` filters to series premieres only (S01E01 airings) — useful for "what's launching soon?"
+
 ### Watch History
 
 ```bash
@@ -81,6 +107,19 @@ trakt-cli history add --watched-at 2025-06-15 "Dark" --json
 - Accepts multiple titles in one call
 - JSON output: `{ "added_episodes": N, "added_movies": N, "not_found_movies": N, "not_found_shows": N }`
 
+### Undo Mark as Watched
+
+```bash
+trakt-cli history remove "Severance" --json
+trakt-cli history remove --type movie "The Godfather" --json
+```
+
+- Removes ALL plays of the matched item — there is no per-watch granular removal
+- Removing a show wipes all its episode plays; removing a movie wipes all its watches
+- `--type show` (default) or `--type movie`
+- JSON output: `{ "deleted_movies", "deleted_episodes", "not_found_movies", "not_found_shows" }`
+- **Warning:** destructive. Confirm with the user before calling on a show with heavy watch history
+
 ### Search
 
 ```bash
@@ -99,6 +138,7 @@ trakt-cli search "Inception" --type movie --json
 
 ## Changelog
 
+- **v2.2.0** — Add `watchlist remove`, `history remove`, and `calendar` commands (`trakt_watchlist_remove`, `trakt_history_remove`, `trakt_calendar` tools). Calendar unlocks forward-looking "what airs next?" workflows.
 - **v2.1.0** — Add `watchlist add` command (`trakt_watchlist_add` tool) for adding movies/shows to the Trakt watchlist
 - **v2.0.0** — Add `progress` command, `--json` flag for all commands (agent-friendly output)
 - **v1.1.0** — Add `watchlist` command, `--type` filter for `history`, `history add` with `--watched-at`


### PR DESCRIPTION
## Summary

Three new commands that complete the CRUD surface for watchlist + history and unlock the first forward-looking capability in the plugin:

1. **`watchlist remove`** / **`trakt_watchlist_remove`** — symmetric inverse of `watchlist add`. Items not on the list are silent no-ops (`deleted_*=0`).
2. **`history remove`** / **`trakt_history_remove`** — undoes mark-as-watched. Removes by trakt id, so it wipes **all** plays of the item (no per-watch granularity — documented in the tool description so agents confirm before calling).
3. **`calendar`** / **`trakt_calendar`** — upcoming episodes of shows the user tracks, in a date window. **This is the only read command in the plugin that returns future-tense data**, enabling proactive "what airs next?" agent workflows.

## Why these three together

- **Remove commands are trivial + symmetric.** They share 90% of their plumbing with the existing add commands — same search → match → POST flow, just a different endpoint path and a different response field. Bundling them avoids three tiny PRs.
- **Calendar is categorically new.** Every other tool in the plugin is reactive (ask → current state). Calendar is the only one that gives the agent future data, which makes it the highest-leverage single command to add for a personal-assistant use case like a cron that DMs "new Severance episode drops Friday."

## What changed

| Area | Change |
|------|--------|
| `api/api.go` | `RemoveWatchlist()`, `RemoveHistory()`, `GetMyShowsCalendar()`. Remove methods reuse the existing `SyncWatchlistReq`/`SyncHistoryReq` shapes (Trakt's add/remove endpoints take identical request bodies). Calendar endpoint path is `/calendars/my/shows[/new]/{start}/{days}`. |
| `cmd/watchlist_remove.go` (new) | Cloned from `watchlist_add.go`, swapped endpoint + response fields |
| `cmd/history_remove.go` (new) | Same pattern; no `--watched-at` flag since the remove endpoint ignores it |
| `cmd/calendar.go` (new) | `--days` (default 7), `--start` (default today), `--new` (series premieres only), `--json`. Validates `--start` format up front. |
| `openclaw/src/index.ts` | Registers 3 new tools. `buildCliArgs` collapses the three title-array commands (`watchlist add`/`remove`, `history remove`) through a shared branch to avoid duplication. Calendar falls through to the generic flag-mapping loop. |
| `cmd/cli_test.go` | Adds `--help` subcases for all three new commands; adds `calendar` to the top-level help listing check |
| Docs | README + `skills/trakt/SKILL.md` document every new command including the destructive-action warning on `history remove`. Skill changelog → v2.2.0. |
| Version bump | 1.7.0 → 1.8.0 across all four manifests |

## Test plan

- [x] `go build ./...` clean
- [x] `npx tsc --noEmit` in `openclaw/` clean
- [x] `go test ./cmd/ -run "TestHelp|TestSubcommandHelp|..."` — all pass, 9 help subcases including the 3 new ones
- [x] **Live end-to-end against real Trakt API:**
  - `calendar --days 14 --json` → 20 upcoming episodes (Shrinking S3E11, BEEF S2, Hacks S5, Your Friends & Neighbors S2, etc.)
  - `calendar --new --days 30 --json` → `{"count": 0, "items": []}` (no series premieres in window — expected)
  - `watchlist remove "The Great British Bake Off" --json` → `deleted_shows: 1` on first call, `deleted_shows: 0` on re-call (confirms the idempotent no-op behavior for items not on the list)
  - `history remove "zzzzzzzzz_not_a_real" --json` → `{"error": "no items matched"}`, exit 0, no POST attempted
- [ ] CI to run on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)