### PR TITLE
feat(oauth): persist refresh_token + 'trakt-cli refresh' + auto-refresh on 401

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trakt",
-  "version": "1.8.14",
+  "version": "1.9.0",
   "description": "Track movies and TV shows using trakt.tv CLI",
   "author": {
     "name": "Omar Shahine"

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -28,6 +29,12 @@ type Credentials struct {
 	ClientID     string `yaml:"client-id"`
 	ClientSecret string `yaml:"client-secret"`
 	AccessToken  string `yaml:"access-token"`
+	// RefreshToken is the long-lived OAuth refresh token returned alongside
+	// AccessToken by the device-code flow. Used by RefreshAccessToken() to
+	// mint a new access token without re-running the device-code dance.
+	// Trakt rotates the refresh token on each refresh, so writeCredentials()
+	// re-persists both fields after every successful refresh.
+	RefreshToken string `yaml:"refresh-token,omitempty"`
 	// UserSlug caches the authenticated user's slug so read-only commands
 	// (watchlist, history, progress) don't have to re-fetch /users/settings
 	// on every invocation. Populated by GetUserSlug() on first use and
@@ -108,6 +115,90 @@ type requestParams struct {
 	auth       bool
 	pagination PaginationsParams
 	query      map[string]string
+	// noAutoRefresh skips the 401 auto-refresh-and-retry path. Set by
+	// RefreshAccessToken() to prevent infinite recursion when the refresh
+	// call itself is rejected. doRequest sets `auth: false` for the refresh
+	// path too, so this is belt-and-suspenders.
+	noAutoRefresh bool
+}
+
+// OAuthRefreshReq is the body of POST /oauth/token with grant_type=refresh_token.
+// Trakt requires redirect_uri (the documented value for first-party clients).
+type OAuthRefreshReq struct {
+	RefreshToken string `json:"refresh_token"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RedirectURI  string `json:"redirect_uri"`
+	GrantType    string `json:"grant_type"`
+}
+
+// OAuthRefreshResp matches the AuthDeviceTokenResp shape — Trakt returns the
+// same envelope for device-code, refresh, and exchange grants.
+type OAuthRefreshResp struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+	CreatedAt    int    `json:"created_at"`
+}
+
+// RefreshAccessToken exchanges c.Credentials.RefreshToken for a fresh access
+// token (and a new rotated refresh token) via POST /oauth/token, mutates
+// c.Credentials in place, and persists the new pair to ~/.trakt.yaml.
+//
+// Returns an error if no refresh token is stored, the API rejects the refresh
+// (e.g. the user revoked the app in Trakt's Connected Apps UI), or persistence
+// fails. On success the next doRequest call uses the new bearer.
+func (c *APIClient) RefreshAccessToken() error {
+	if c.Credentials.RefreshToken == "" {
+		return fmt.Errorf("no refresh token stored; run `trakt-cli auth` to bootstrap")
+	}
+
+	body := OAuthRefreshReq{
+		RefreshToken: c.Credentials.RefreshToken,
+		ClientID:     c.Credentials.ClientID,
+		ClientSecret: c.Credentials.ClientSecret,
+		// Documented value for first-party device-code clients.
+		RedirectURI: "urn:ietf:wg:oauth:2.0:oob",
+		GrantType:   "refresh_token",
+	}
+
+	resp, err := c.doRequest(requestParams{
+		method:        http.MethodPost,
+		path:          "/oauth/token",
+		body:          body,
+		auth:          false,
+		noAutoRefresh: true,
+	})
+	if err != nil {
+		return fmt.Errorf("refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain enough of the body to surface Trakt's error envelope without
+		// dumping a giant HTML page in the unlikely 5xx-from-edge case.
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("refresh rejected (%s): %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+
+	var fresh OAuthRefreshResp
+	if err := json.NewDecoder(resp.Body).Decode(&fresh); err != nil {
+		return fmt.Errorf("refresh response decode: %w", err)
+	}
+	if fresh.AccessToken == "" {
+		return fmt.Errorf("refresh response missing access_token")
+	}
+
+	c.Credentials.AccessToken = fresh.AccessToken
+	if fresh.RefreshToken != "" {
+		// Trakt rotates the refresh token on every refresh — must persist the
+		// new one or the next refresh fails with invalid_grant.
+		c.Credentials.RefreshToken = fresh.RefreshToken
+	}
+	c.writeCredentials()
+	return nil
 }
 
 func (c *APIClient) doRequest(params requestParams) (*http.Response, error) {
@@ -166,6 +257,35 @@ func (c *APIClient) doRequest(params requestParams) (*http.Response, error) {
 			RetryAfterSeconds: retryAfter,
 			Status:            resp.Status,
 		}
+	}
+
+	// Auto-refresh on 401: if the access token expired (or was revoked) and
+	// we have a refresh token, refresh once and retry. This is best-effort —
+	// the original 401 is returned if refresh fails for any reason, so the
+	// caller sees a normal auth failure instead of a silent retry loop.
+	// Only fires when this call carried auth headers, has a refresh token,
+	// and isn't itself the refresh call (noAutoRefresh).
+	if resp.StatusCode == http.StatusUnauthorized &&
+		params.auth &&
+		!params.noAutoRefresh &&
+		c.Credentials.RefreshToken != "" {
+		resp.Body.Close()
+		if refreshErr := c.RefreshAccessToken(); refreshErr != nil {
+			logrus.WithError(refreshErr).Warn("trakt-cli: 401 on " + params.path + " and refresh failed; returning original auth error")
+			// Re-issue the original request to get back a clean 401 response
+			// for the caller to interpret. Recurse with noAutoRefresh to avoid
+			// loops if the refresh somehow partially succeeded.
+			retryParams := params
+			retryParams.noAutoRefresh = true
+			return c.doRequest(retryParams)
+		}
+		// Refresh succeeded — retry the original request once with the new
+		// bearer. Set noAutoRefresh so we don't recurse if the new token is
+		// somehow also rejected (extremely rare; means Trakt revoked the
+		// account, not the token).
+		retryParams := params
+		retryParams.noAutoRefresh = true
+		return c.doRequest(retryParams)
 	}
 
 	return resp, nil

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -27,6 +27,11 @@ type Credentials struct {
 	ClientID     string `yaml:"client-id"`
 	ClientSecret string `yaml:"client-secret"`
 	AccessToken  string `yaml:"access-token"`
+	// RefreshToken persists the long-lived OAuth refresh token from the
+	// device-code flow so `trakt-cli refresh` (and the doRequest 401
+	// auto-refresh path) can mint new access tokens without re-running
+	// the device-code dance. Kept in sync with api.Credentials.
+	RefreshToken string `yaml:"refresh-token,omitempty"`
 	// UserSlug is populated post-auth by fetching /users/settings once so
 	// subsequent read commands can use the cached value without a round-trip.
 	// Kept in sync with api.Credentials — see api/api.go.
@@ -95,6 +100,7 @@ var authCmd = &cobra.Command{
 					ClientID:     clientID,
 					ClientSecret: clientSecret,
 					AccessToken:  tokenResp.AccessToken,
+					RefreshToken: tokenResp.RefreshToken,
 				}
 
 				// Prime the user-slug cache: fetch /users/settings once now so
@@ -106,6 +112,7 @@ var authCmd = &cobra.Command{
 					ClientID:     creds.ClientID,
 					ClientSecret: creds.ClientSecret,
 					AccessToken:  creds.AccessToken,
+					RefreshToken: creds.RefreshToken,
 				})
 				if settings, slugErr := primerClient.GetUserSettings(); slugErr == nil {
 					creds.UserSlug = settings.User.Ids.Slug

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/omarshahine/trakt-plugin/api"
+	"github.com/spf13/cobra"
+)
+
+// refreshOutput is the --json payload for scripts/launchd consumers.
+type refreshOutput struct {
+	OK           bool   `json:"ok"`
+	RefreshedAt  string `json:"refreshed_at"`
+	UserSlug     string `json:"user_slug,omitempty"`
+	HasRefresh   bool   `json:"has_refresh_token"`
+	Error        string `json:"error,omitempty"`
+	NextRunHint  string `json:"next_run_hint,omitempty"`
+}
+
+var refreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Refresh the Trakt OAuth access token using the stored refresh token",
+	Long: `Exchange the stored refresh_token (~/.trakt.yaml) for a fresh access_token
+without re-running the device-code flow. Trakt rotates the refresh_token on
+each refresh, so this command re-persists both fields atomically.
+
+Returns exit 0 on success, exit 1 if no refresh_token is stored or the refresh
+is rejected (e.g. the app was revoked in Trakt's Connected Apps UI — in that
+case, run 'trakt-cli auth' to bootstrap again).
+
+Designed to be called by a weekly launchd job so the access token never
+expires unattended. The doRequest path also auto-refreshes transparently on
+401, so this command is belt-and-suspenders — useful for predictable refresh
+cadence and audit logging.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonOut, _ := cmd.Flags().GetBool("json")
+
+		client := api.NewAPIClient()
+		out := refreshOutput{
+			RefreshedAt: time.Now().UTC().Format(time.RFC3339),
+			HasRefresh:  client.Credentials.RefreshToken != "",
+		}
+
+		if err := client.RefreshAccessToken(); err != nil {
+			out.OK = false
+			out.Error = err.Error()
+			if jsonOut {
+				_ = json.NewEncoder(os.Stdout).Encode(out)
+			} else {
+				fmt.Fprintf(os.Stderr, "trakt-cli refresh failed: %v\n", err)
+				if client.Credentials.RefreshToken == "" {
+					fmt.Fprintln(os.Stderr, "hint: run 'trakt-cli auth' to bootstrap with a refresh token persisted")
+				}
+			}
+			os.Exit(1)
+		}
+
+		out.OK = true
+		out.HasRefresh = client.Credentials.RefreshToken != ""
+		// Best-effort slug — useful for confirming the token actually works.
+		if slug, slugErr := client.GetUserSlug(); slugErr == nil {
+			out.UserSlug = slug
+		}
+		// Trakt access tokens are 90 days; recommend refresh well inside that.
+		out.NextRunHint = "schedule weekly via launchd; current token valid for ~90 days"
+
+		if jsonOut {
+			_ = json.NewEncoder(os.Stdout).Encode(out)
+		} else {
+			fmt.Printf("Refreshed Trakt OAuth token at %s (user=%s)\n", out.RefreshedAt, out.UserSlug)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(refreshCmd)
+}

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
       "name": "trakt",
       "source": "./openclaw",
       "description": "Track movies and TV shows via trakt.tv",
-      "version": "1.8.14"
+      "version": "1.9.0"
     }
   ]
 }

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "trakt-tools",
   "name": "Trakt",
   "description": "Track movies and TV shows using trakt.tv",
-  "version": "1.8.14",
+  "version": "1.9.0",
   "requires": {
     "binaries": ["trakt-cli"],
     "envVars": [

--- a/openclaw/package-lock.json
+++ b/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trakt-tools",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trakt-tools",
-      "version": "1.8.9",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trakt-tools",
-  "version": "1.8.14",
+  "version": "1.9.0",
   "description": "OpenClaw plugin for Trakt.tv - track movies and TV shows",
   "type": "module",
   "openclaw": {


### PR DESCRIPTION
## Summary

The device-code flow has always received a `refresh_token` in `AuthDeviceTokenResp`, but `cmd/auth.go` discarded it — `Credentials` had no slot for it and no `RefreshAccessToken()` method existed. Result: every time the access token expired (Trakt issues 90-day tokens; mine just died at 13 days, likely via app-revoke in the Trakt UI), users had to redo the full device-code dance.

This PR closes that gap end-to-end: persists the refresh_token, adds an explicit `trakt-cli refresh` subcommand for scheduled refresh jobs, and adds transparent auto-refresh-on-401 inside `api.doRequest` so the next CLI call after a token expiry just works.

## Changes

| File | What |
|------|------|
| `api/api.go` | Add `RefreshToken` field to `Credentials`. New `OAuthRefreshReq/Resp` types + `RefreshAccessToken()` method (POST `/oauth/token` grant_type=refresh_token). Re-persists rotated token via `writeCredentials()`. Auto-refresh hook in `doRequest`: on 401 with auth + non-empty refresh_token + not `noAutoRefresh`, refresh once and retry. Single-attempt — no infinite-loop risk. |
| `cmd/auth.go` | Add `RefreshToken` to the marshaling-side `Credentials` struct (kept in sync with `api.Credentials` per the existing comment). Persist `tokenResp.RefreshToken` after device-code exchange, both on disk and in the in-memory primer client. |
| `cmd/refresh.go` *(new)* | `trakt-cli refresh` subcommand. Calls `RefreshAccessToken()`, surfaces structured JSON via `--json` (ok, refreshed_at, user_slug, has_refresh_token, error, next_run_hint), exit 1 on failure with a hint to run `trakt-cli auth` if no refresh_token is stored. Designed for weekly launchd / cron use. |
| 4× version files | 1.8.10 → 1.9.0 (minor: new public API, new subcommand, new Credentials field — all backwards-compatible). |
| `openclaw/package-lock.json` | Regenerated from new package.json (was lagging at 1.8.9 from a prior release). |

## Why both auto-refresh AND an explicit subcommand?

- **Auto-refresh on 401** is the best UX for ad-hoc CLI runs — token expires, user notices nothing, next call just works.
- **`trakt-cli refresh` subcommand** is belt-and-suspenders for scheduled use: predictable cadence, audit log entry per refresh, structured JSON exit signal for launchd/cron wrappers. Also surfaces the "no refresh_token stored — run `trakt-cli auth`" path cleanly when called from automation.

## Backwards compatibility

- Existing `~/.trakt.yaml` files without `refresh-token` continue to work for the lifetime of their current access token. Once it expires they'll hit the standard 401 path (no refresh_token to auto-refresh from) and need `trakt-cli auth` once — exactly today's behavior, no regression.
- After running `trakt-cli auth` on this version, the refresh_token is persisted and subsequent expirations are handled transparently.
- Yaml field is `omitempty`, so omitting it from the file is fine.

## Test plan

- [x] `go build` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — pass (cmd integration tests, 67s)
- [ ] Bootstrap on my live install: `trakt-cli auth` → verify `refresh-token` line appears in `~/.trakt.yaml`
- [ ] Call `trakt-cli refresh --json` → verify rotation: new access_token + new refresh_token in file
- [ ] Force expiry by replacing access-token with garbage → next `trakt-cli watchlist` succeeds via auto-refresh path
- [ ] Schedule `com.lobster.trakt-refresh` launchd weekly

## Follow-up

- After merge, set up `com.lobster.trakt-refresh` LaunchAgent (weekly cadence well inside the 90-day token lifetime; gives ~13 refresh attempts per access token TTL as a safety margin)
- Update the lobster smoke test to also exercise `trakt-cli refresh` end-to-end so we catch regressions in CI