### PR TITLE
chore: release Trakt plugin 1.9.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trakt",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Track movies and TV shows using trakt.tv CLI",
   "author": {
     "name": "Omar Shahine"

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
       "name": "trakt",
       "source": "./openclaw",
       "description": "Track movies and TV shows via trakt.tv",
-      "version": "1.9.0"
+      "version": "1.9.1"
     }
   ]
 }

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "trakt-tools",
   "name": "Trakt",
   "description": "Track movies and TV shows using trakt.tv",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package-lock.json
+++ b/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trakt-tools",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trakt-tools",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trakt-tools",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "OpenClaw plugin for Trakt.tv - track movies and TV shows",
   "type": "module",
   "openclaw": {


### PR DESCRIPTION
Version bump for the OpenClaw SDK refresh. Version consistency was checked locally before pushing.